### PR TITLE
Support pagination

### DIFF
--- a/fbalbumdownload.py
+++ b/fbalbumdownload.py
@@ -76,13 +76,14 @@ def inputUserID(GRAPH, GUI):
 def paginate(GRAPH, request_output):
     done = False
     running_output = request_output
+    api_url = "https://graph.facebook.com/"
     while(not done):
         for output in running_output['data']:
             yield output
         if "paging" in running_output and "next" in running_output['paging']:
             next_url = running_output['paging']['next']
-            if next_url.startswith("https://graph.facebook.com/"):
-                next_url = next_url[len("https://graph.facebook.com/"):]
+            if next_url.startswith(api_url):
+                next_url = next_url[len(api_url):]
             else:
                 raise ValueError("Next URL did not start with graph.facebook.com")
             running_output = GRAPH.request(next_url)


### PR DESCRIPTION
Certain calls on facebook have hard limits (that even passing limit=5000 won't surpass) to ensure the queries return in a timely fashion.  The album photos call is one of those and hard limits to 100 (which then causes the downloader to stop because it's waiting until the number of photos in the album have been downloaded, rather than the number of URLs it actually has in its list).  This page automatically goes through the pages yielding all the data items.

It doesn't fix the fact that the progressbar will wait forever if the number of URLs and the album count don't match, but at least this will let people know when the number of URLs doesn't match the album count.
